### PR TITLE
Add CLI app for option payoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Option Payoff Application
+
+This simple command line application lets you build an option portfolio and plot the payoff diagram.
+
+## Requirements
+
+- Python 3
+- `numpy` and `matplotlib` packages
+
+Install dependencies (if not already available):
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the application:
+
+```bash
+python option_app.py
+```
+
+Use the menu to add options (call or put, long or short) with their parameters. Choose "Show payoff graph" to see the resulting payoff curve.

--- a/option_app.py
+++ b/option_app.py
@@ -1,0 +1,99 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+class Option:
+    def __init__(self, opt_type, direction, strike, premium, quantity=1):
+        self.opt_type = opt_type.lower()
+        self.direction = 1 if direction in [1, 'long', 'buy', 'comprado', 'compra'] else -1
+        self.strike = float(strike)
+        self.premium = float(premium)
+        self.quantity = int(quantity)
+
+    def payoff(self, price):
+        price = float(price)
+        if self.opt_type == 'call':
+            intrinsic = max(price - self.strike, 0)
+        else:
+            intrinsic = max(self.strike - price, 0)
+        if self.direction == 1:
+            return self.quantity * (intrinsic - self.premium)
+        else:
+            return self.quantity * (self.premium - intrinsic)
+
+class Portfolio:
+    def __init__(self):
+        self.options = []
+
+    def add_option(self, option):
+        self.options.append(option)
+
+    def payoff(self, price):
+        return sum(opt.payoff(price) for opt in self.options)
+
+    def price_range(self):
+        if not self.options:
+            return np.linspace(0, 100, 100)
+        strikes = [opt.strike for opt in self.options]
+        min_price = min(strikes) * 0.5
+        max_price = max(strikes) * 1.5
+        return np.linspace(min_price, max_price, 200)
+
+    def __str__(self):
+        lines = []
+        for i, opt in enumerate(self.options, 1):
+            dir_text = 'Long' if opt.direction == 1 else 'Short'
+            lines.append(f"{i}. {dir_text} {opt.opt_type.title()} - Strike {opt.strike} - Premium {opt.premium} - Qty {opt.quantity}")
+        return "\n".join(lines)
+
+
+def main():
+    portfolio = Portfolio()
+
+    while True:
+        print("\nCurrent portfolio:")
+        if portfolio.options:
+            print(portfolio)
+        else:
+            print("(empty)")
+        print("\nMenu:")
+        print("1. Add option")
+        print("2. Show payoff graph")
+        print("3. Exit")
+        choice = input("Select: ").strip()
+
+        if choice == '1':
+            opt_type = input("Option type (call/put): ").strip().lower()
+            if opt_type not in {'call', 'put'}:
+                print("Invalid option type. Use 'call' or 'put'.")
+                continue
+            direction = input("Direction (long/short): ").strip().lower()
+            if direction not in {'long', 'short'}:
+                print("Invalid direction. Use 'long' or 'short'.")
+                continue
+            strike = input("Strike price: ")
+            premium = input("Premium: ")
+            quantity = input("Quantity (default 1): ").strip() or '1'
+            option = Option(opt_type, direction, strike, premium, quantity)
+            portfolio.add_option(option)
+            print("Option added.")
+        elif choice == '2':
+            if not portfolio.options:
+                print("No options in portfolio.")
+                continue
+            prices = portfolio.price_range()
+            payoff = [portfolio.payoff(p) for p in prices]
+            plt.figure()
+            plt.plot(prices, payoff, label='Payoff')
+            plt.axhline(0, color='gray', linestyle='--')
+            plt.xlabel('Underlying Price')
+            plt.ylabel('Profit / Loss')
+            plt.title('Option Strategy Payoff')
+            plt.legend()
+            plt.show()
+        elif choice == '3':
+            break
+        else:
+            print("Invalid selection.")
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+matplotlib
+numpy


### PR DESCRIPTION
## Summary
- add a simple command line tool to create option strategies and plot payoff graphs
- document setup and usage in README
- include basic requirements list

## Testing
- `python3 option_app.py <<'EOF'
3
EOF`
- `pip install numpy matplotlib --quiet` *(fails: cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6879c1d24094832fa7bce55d6b691933